### PR TITLE
Refactor callback args

### DIFF
--- a/embed/delphi/src/NodeEngine.pas
+++ b/embed/delphi/src/NodeEngine.pas
@@ -115,7 +115,7 @@ begin
     Result := Prop.GetValue(Obj);
     JSResult := TValueToJSValue(Result, Engine);
     if Assigned(JSResult) then
-      Args.SetGetterResult(JSResult);
+      Args.SetReturnValue(JSResult);
   end;
 end;
 
@@ -146,7 +146,7 @@ begin
     Result := Prop.GetValue(Obj);
     JSValue := TValueToJSValue(Result, Engine);
     if Assigned(JSValue) then
-      Args.SetSetterResult(JSValue);
+      Args.SetReturnValue(JSValue);
   end;
 end;
 

--- a/embed/delphi/src/NodeInterface.pas
+++ b/embed/delphi/src/NodeInterface.pas
@@ -85,39 +85,31 @@ type
     procedure SetParent(parent: IClassTemplate); virtual; stdcall; abstract;
   end;
 
-  IMethodArgs = class (IBaseInterface)
+  IBaseArgs = class (IBaseInterface)
     function GetEngine: TObject; virtual; stdcall; abstract;
     function GetDelphiObject: TObject; virtual; stdcall; abstract;
     function GetDelphiClasstype: TClass; virtual; stdcall; abstract;
+    procedure SetReturnValue(val: IJSValue); virtual; stdcall; abstract;
+  end;
+
+  IMethodArgs = class (IBaseArgs)
     function GetArgs: IJSArray; virtual; stdcall; abstract;
 
     function GetMethodName: PAnsiChar; virtual; stdcall; abstract;
 
-    procedure SetReturnValue(val: IJSValue); virtual; stdcall; abstract;
-
     function GetDelphiMethod: TObject; virtual; stdcall; abstract;
   end;
 
-  IGetterArgs = class (IBaseInterface)
-    function GetEngine: TObject; virtual; stdcall; abstract;
-    function GetDelphiObject: Pointer; virtual; stdcall; abstract;
-    function GetDelphiClasstype: Pointer; virtual; stdcall; abstract;
+  IGetterArgs = class (IBaseArgs)
     function GetPropName: IJSValue; virtual; stdcall; abstract;
     function GetProp: TObject; virtual; stdcall; abstract;
-
-    procedure SetGetterResult(val: IJSValue); virtual; stdcall; abstract;
   end;
 
-  ISetterArgs = class (IBaseInterface)
-    function GetEngine: TObject; virtual; stdcall; abstract;
-    function GetDelphiObject: Pointer; virtual; stdcall; abstract;
-    function GetDelphiClasstype: Pointer; virtual; stdcall; abstract;
+  ISetterArgs = class (IBaseArgs)
     function GetPropName: IJSValue; virtual; stdcall; abstract;
     function GetProp: TObject; virtual; stdcall; abstract;
 
     function GetPropValue: IJSValue; virtual; stdcall; abstract;
-
-    procedure SetSetterResult(val: IJSValue); virtual; stdcall; abstract;
   end;
 
   TMethodCallBack = procedure(args: IMethodArgs); stdcall;

--- a/src/delphi_intf.cpp
+++ b/src/delphi_intf.cpp
@@ -688,7 +688,7 @@ namespace embed {
     }
     return nullptr;
   }
-  void IGetterArgs::SetGetterResult(IJSValue * val)
+  void IGetterArgs::SetReturnValue(IJSValue * val)
   {
     if (val)
       propinfo->GetReturnValue().Set(val->V8Value());
@@ -748,7 +748,7 @@ namespace embed {
   {
     return propValue;
   }
-  void ISetterArgs::SetSetterResult(IJSValue * val)
+  void ISetterArgs::SetReturnValue(IJSValue * val)
   {
     propinfo->GetReturnValue().Set(val->V8Value());
   }

--- a/src/delphi_intf.h
+++ b/src/delphi_intf.h
@@ -138,7 +138,14 @@ namespace embed {
     std::vector<std::unique_ptr<IClassMethod>> methods;
   };
 
-  class IMethodArgs : public IBaseIntf {
+  class IBaseArgs : public IBaseIntf {
+    virtual void * APIENTRY GetEngine() abstract;
+    virtual void * APIENTRY GetDelphiObject() abstract;
+    virtual void * APIENTRY GetDelphiClasstype() abstract;
+    virtual void APIENTRY SetReturnValue(IJSValue * val) abstract;
+  };
+
+  class IMethodArgs : public IBaseArgs {
   public:
     IMethodArgs(const v8::FunctionCallbackInfo<v8::Value>& newArgs);
     virtual void * APIENTRY GetEngine();
@@ -159,7 +166,7 @@ namespace embed {
     std::string run_string_result;
   };
 
-  class IGetterArgs : public IBaseIntf {
+  class IGetterArgs : public IBaseArgs {
   public:
     IGetterArgs(const v8::PropertyCallbackInfo<v8::Value>& info,
       v8::Local<v8::Value> prop);
@@ -170,7 +177,7 @@ namespace embed {
     virtual IJSValue * APIENTRY GetPropName();
     virtual void * APIENTRY GetPropPointer();
 
-    virtual void APIENTRY SetGetterResult(IJSValue * val);
+    virtual void APIENTRY SetReturnValue(IJSValue * val);
   private:
     v8::Isolate * iso = nullptr;
     IEmbedEngine * engine = nullptr;
@@ -179,7 +186,7 @@ namespace embed {
     const v8::PropertyCallbackInfo<v8::Value> * propinfo = nullptr;
   };
 
-  class ISetterArgs : public IBaseIntf {
+  class ISetterArgs : public IBaseArgs {
   public:
     ISetterArgs(const v8::PropertyCallbackInfo<void>& info,
                 v8::Local<v8::Value> prop,
@@ -193,7 +200,7 @@ namespace embed {
 
     virtual IJSValue * APIENTRY GetValue();
 
-    virtual void APIENTRY SetSetterResult(IJSValue * val);
+    virtual void APIENTRY SetReturnValue(IJSValue * val);
   private:
     v8::Isolate * iso = nullptr;
     IEmbedEngine * engine = nullptr;


### PR DESCRIPTION
refactor callback args for delphi object.

Add base args class, that declares common methods for all callback args classes.