### PR TITLE
fix wrapping delphi object to JS value

### DIFF
--- a/embed/delphi/src/NodeInterface.pas
+++ b/embed/delphi/src/NodeInterface.pas
@@ -130,6 +130,8 @@ type
       virtual; stdcall; abstract;
     function AddObject(className: PAnsiChar; classType: Pointer): IClassTemplate;
       virtual; stdcall; abstract;
+    function GetObjectTemplate(classType: TClass): IClassTemplate;
+      virtual; stdcall; abstract;
     function AddEnum(enumName: PAnsiChar): IEnumTemplate;
       virtual; stdcall; abstract;
     procedure AddGlobalVariableObject(name: PAnsiChar; obj: TObject;

--- a/src/delphi_intf.cpp
+++ b/src/delphi_intf.cpp
@@ -111,6 +111,23 @@ namespace embed {
     return result;
   }
 
+  IClassTemplate * IEmbedEngine::GetObjectTemplate(void * classType)
+  {
+    IClassTemplate * result = nullptr;
+    if (globalTemplate && globalTemplate->dClass == classType) {
+      result = globalTemplate;
+    }
+    if (!result) {
+      for (auto &templ : classes) {
+        if (templ->dClass == classType) {
+          result = templ.get();
+          break;
+        }
+      }
+    }
+    return result;
+  }
+
   IEnumTemplate * IEmbedEngine::AddEnum(char * enumName)
   {
     auto enumerator = std::make_unique<IEnumTemplate>(enumName);
@@ -301,8 +318,9 @@ namespace embed {
               v8::External::New(Isolate(), cType));
             obj->SetInternalField(OBJECT_INTERNAL_FIELD_NUMBER,
               v8::External::New(Isolate(), value));
-            result = new IJSDelphiObject(Isolate(), obj);
-            JSDelphiObjects.emplace(std::make_pair(hash, result));
+            result = IJSValue::MakeValue(Isolate(), obj)->AsDelphiObject();
+            if (result)
+              JSDelphiObjects.emplace(std::make_pair(hash, result));
           }
         }
       }

--- a/src/delphi_intf.h
+++ b/src/delphi_intf.h
@@ -274,6 +274,9 @@ namespace embed {
     virtual IClassTemplate * APIENTRY AddGlobal(void * dClass);
     virtual IClassTemplate * APIENTRY AddObject(char * className,
       void * classType);
+    // Get class template by delphi's classtype. Returns nullptr if tepmlate
+    // wasn't created
+    virtual IClassTemplate * APIENTRY GetObjectTemplate(void * classType);
     virtual IEnumTemplate * APIENTRY AddEnum(char * enumName);
     // Add Delphi object as global variable. In JS it has no difference with
     // global template's protperty, but here it will return wrapped Delphi


### PR DESCRIPTION
Wrap object only if it have registered class type (check from original classtype to last parent).