### PR TITLE
fix after update node sources to 8.11.3

### DIFF
--- a/src/embed.cpp
+++ b/src/embed.cpp
@@ -15,6 +15,8 @@ namespace embed {
                                            nullptr);
       v8::V8::InitializePlatform(v8_platform);
       v8::V8::Initialize();
+      node::tracing::TraceEventHelper::SetTracingController(
+        new v8::TracingController());
 
       initialized = true;
     }
@@ -126,6 +128,7 @@ namespace embed {
       delete script_params;
       iso->Dispose();
       running = false;
+      node::ClearStaticData();
     }
   }
   void IBaseIntf::Delete()

--- a/src/node.cc
+++ b/src/node.cc
@@ -4649,6 +4649,14 @@ void Init(int* argc,
   node_is_initialized = true;
 }
 
+NODE_EXTERN void ClearStaticData()
+{
+  modlist_addon = nullptr;
+  modlist_builtin = nullptr;
+  modlist_internal = nullptr;
+  modlist_linked = nullptr;
+  eval_string = nullptr;
+}
 
 void RunAtExit(Environment* env) {
   env->RunAtExitCallbacks();

--- a/src/node.h
+++ b/src/node.h
@@ -204,6 +204,7 @@ NODE_EXTERN void Init(int* argc,
                       const char** argv,
                       int* exec_argc,
                       const char*** exec_argv);
+NODE_EXTERN void ClearStaticData();
 
 class IsolateData;
 class Environment;


### PR DESCRIPTION
Important: this pr changes native node source code. If nodejs will have its own function to clear static data, then changes in node.cc and node.h files should be reverted.