### PR TITLE
node: free .node modules at arguments reset

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4656,6 +4656,16 @@ NODE_EXTERN void ResetArguments()
   modlist_builtin = nullptr;
   modlist_internal = nullptr;
   modlist_linked = nullptr;
+  // free all connected .node modules to include them at next start
+  for (auto mp = modlist_addon; mp != nullptr;) {
+    if (mp->nm_dso_handle) {
+      uv_lib_t lib;
+      lib.errmsg = NULL;
+      lib.handle = HMODULE(mp->nm_dso_handle);
+      mp = mp->nm_link;
+      uv_dlclose(&lib);
+    }
+  }
   modlist_addon = nullptr;
   debug_options.Reset();
 }


### PR DESCRIPTION
Free .node modules at arguments reset allows to register them again at next require.
Possible problem: modules are global, so after running second engine,
first engine (if it still active) will lose connected .node modules